### PR TITLE
docs: replaced "message" by "text"

### DIFF
--- a/packages/paperdave-logger/README.md
+++ b/packages/paperdave-logger/README.md
@@ -54,7 +54,7 @@ import { Spinner } from '@paperdave/logger';
 import { delay } from '@paperdave/utils';
 
 const spinner = new Spinner({
-  message: 'Loading...'
+  text: 'Loading...'
 });
 await delay(1000);
 spinner.update('Still Loading...');


### PR DESCRIPTION
The code has been changed to "text", so the documentations should follow this.