### PR TITLE
Fix: Changed target to `es6` to prevent usage of nullish coalescing operator

### DIFF
--- a/.changeset/sharp-goats-kiss.md
+++ b/.changeset/sharp-goats-kiss.md
@@ -1,0 +1,5 @@
+---
+"@paperdave/logger": patch
+---
+
+Using ES6 instead of ES2020 to prevent usage of nullish coalescing operator

--- a/packages/paperdave-logger/package.json
+++ b/packages/paperdave-logger/package.json
@@ -15,7 +15,7 @@
     "screenshot.png"
   ],
   "scripts": {
-    "build": "tsc && esbuild --outfile=./dist/index.js --target=es2020 --format=esm --platform=node --sourcemap --bundle src/index.ts --external:wrap-ansi --external:supports-color"
+    "build": "tsc && esbuild --outfile=./dist/index.js --target=es6 --format=esm --platform=node --sourcemap --bundle src/index.ts --external:wrap-ansi --external:supports-color"
   },
   "dependencies": {
     "supports-color": "^9.2.2",


### PR DESCRIPTION
Fixes #27 